### PR TITLE
Fix: test page should use local version of script

### DIFF
--- a/src/crux/tests/test-basic.njk
+++ b/src/crux/tests/test-basic.njk
@@ -8,7 +8,7 @@ permalink: /crux/tests/basic/index.html
     <meta name="robots" content="noindex, nofollow">
     <title>GPT Test with Lazy Loading + Refresh if Viewable</title>
     <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script async src="{%- if settings.environment == "production" %}{{ settings.url }}{% endif -%}/crux/dist/js/vmr-crux-gpt.min.js"></script>
+    <script async src="/crux/dist/js/vmr-crux-gpt.min.js"></script>
   </head>
   <body>
 


### PR DESCRIPTION
Set the test page to load the VMR JS file from the relative path e.g. `/crux/dist/js/vmr-crux-gpt.min.js` instead of the absolute path. This is so that the test page will always use the local version of the file.